### PR TITLE
Update Week 5 models and fix daily metrics merge grain

### DIFF
--- a/data-tests/test_fact_daily_metrics_kl.sql
+++ b/data-tests/test_fact_daily_metrics_kl.sql
@@ -1,0 +1,69 @@
+-- Test: validate fact_daily_metrics_kl foreign keys and grain uniqueness
+-- Expected result: 0 rows
+
+WITH grain_duplicates AS (
+    SELECT
+        'duplicate_fact_grain' AS issue,
+        date_key,
+        geo_key,
+        device_class,
+        mkt_source,
+        mkt_campaign,
+        COUNT(*) AS issue_count
+    FROM {{ ref('fact_daily_metrics_kl') }}
+    GROUP BY
+        date_key,
+        geo_key,
+        device_class,
+        mkt_source,
+        mkt_campaign
+    HAVING COUNT(*) > 1
+),
+
+orphan_date_keys AS (
+    SELECT
+        'orphan_date_key' AS issue,
+        f.date_key,
+        f.geo_key,
+        f.device_class,
+        f.mkt_source,
+        f.mkt_campaign,
+        COUNT(*) AS issue_count
+    FROM {{ ref('fact_daily_metrics_kl') }} f
+    LEFT JOIN {{ ref('dim_date_kl') }} d
+        ON f.date_key = d.date_key
+    WHERE d.date_key IS NULL
+    GROUP BY
+        f.date_key,
+        f.geo_key,
+        f.device_class,
+        f.mkt_source,
+        f.mkt_campaign
+),
+
+orphan_geo_keys AS (
+    SELECT
+        'orphan_geo_key' AS issue,
+        f.date_key,
+        f.geo_key,
+        f.device_class,
+        f.mkt_source,
+        f.mkt_campaign,
+        COUNT(*) AS issue_count
+    FROM {{ ref('fact_daily_metrics_kl') }} f
+    LEFT JOIN {{ ref('dim_geography_kl') }} g
+        ON f.geo_key = g.geo_key
+    WHERE g.geo_key IS NULL
+    GROUP BY
+        f.date_key,
+        f.geo_key,
+        f.device_class,
+        f.mkt_source,
+        f.mkt_campaign
+)
+
+SELECT * FROM grain_duplicates
+UNION ALL
+SELECT * FROM orphan_date_keys
+UNION ALL
+SELECT * FROM orphan_geo_keys

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -29,7 +29,7 @@ seeds:
 models:
   brave_de_project:
     database: BRAVE_DATABASE
-    schema: PROJECT_TEST
+    +schema: PROJECT_TEST
     raw_data:
       +materialized: table
     data_mart:

--- a/models/data_mart/dim_post_sales_pipeline_kl.sql
+++ b/models/data_mart/dim_post_sales_pipeline_kl.sql
@@ -1,0 +1,55 @@
+/*
+****************************************************************************************************
+MODEL: dim_post_sales_pipeline_kl
+PURPOSE: 
+    - Track the progression of a user/product combination through the sales funnel for completed transactions.
+    - Measure the time duration (velocity) between key milestones from discovery to purchase.
+SOURCE: 
+    - raw.user_journey
+BUSINESS VALUE:
+    - Analyzes the efficiency of the conversion path for successful sales.
+    - Provides historical velocity data to understand typical customer decision cycles.
+    - Helps Marketing and Product teams identify the touchpoints that lead to faster checkouts.
+****************************************************************************************************
+*/
+
+{{ config(
+    materialized='table'
+) }}
+
+-- Step 1: Identify the first timestamp for each milestone per user/product pair
+WITH milestone_timestamps AS (
+    SELECT
+        user_id,
+        product_id,
+        -- Using MIN to find the very first touchpoint for each stage
+        MIN(CASE WHEN search_event_id IS NOT NULL THEN to_timestamp(replace(timestamp,' UTC','')) END) AS search_time,  -- ✅ 修正: 通过搜索发现
+        MIN(CASE WHEN has_atc = TRUE THEN to_timestamp(replace(timestamp,' UTC','')) END) AS atc_time,
+        MIN(CASE WHEN has_purchase = TRUE THEN to_timestamp(replace(timestamp,' UTC','')) END) AS purchase_time
+    FROM {{ source('de_project', 'user_journey') }}
+    GROUP BY user_id, product_id
+),
+
+-- Step 2: Calculate metrics using the earliest touchpoint as start
+pipeline_metrics AS (
+    SELECT
+        user_id,
+        product_id,
+        search_time,
+        atc_time,
+        purchase_time,
+        DATEDIFF('minute', search_time, atc_time) AS search_to_atc_min,
+        DATEDIFF('minute', atc_time, purchase_time) AS atc_to_purchase_min,
+        -- Using LEAST and NVL to pick the earliest starting point between Search and ATC
+        DATEDIFF('minute', 
+            LEAST(NVL(search_time, atc_time), NVL(atc_time, search_time)), 
+            purchase_time
+        ) AS total_duration_min
+    FROM milestone_timestamps
+)
+
+-- Step 3: Filter the data we need
+SELECT * 
+FROM pipeline_metrics
+WHERE purchase_time IS NOT NULL 
+  AND (search_time IS NOT NULL OR atc_time IS NOT NULL)

--- a/models/data_mart/fact_daily_metrics_kl.sql
+++ b/models/data_mart/fact_daily_metrics_kl.sql
@@ -1,0 +1,60 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key=['date_key', 'geo_key', 'device_class', 'mkt_source', 'mkt_campaign']
+) }}
+
+SELECT
+    -- Foreign keys
+    d.date_key,
+    g.geo_key,
+
+    -- Degenerate dimensions
+    uj.device_class,
+    COALESCE(uj.mkt_source, 'organic') AS mkt_source,
+    COALESCE(uj.mkt_campaign, 'none') AS mkt_campaign,
+
+    -- User metrics
+    COUNT(DISTINCT uj.user_id) AS daily_active_users,
+    COUNT(DISTINCT CASE WHEN uj.has_qv THEN uj.user_id END) AS unique_qv_users,
+    COUNT(DISTINCT CASE WHEN uj.has_purchase THEN uj.user_id END) AS unique_buyers,
+
+    -- Event metrics
+    SUM(CASE WHEN uj.has_qv THEN 1 ELSE 0 END) AS qv_count,
+    SUM(CASE WHEN uj.has_pdp THEN 1 ELSE 0 END) AS pdp_view_count,
+    SUM(CASE WHEN uj.has_atc THEN 1 ELSE 0 END) AS add_to_cart_count,
+    SUM(CASE WHEN uj.has_purchase THEN 1 ELSE 0 END) AS purchase_count,
+
+    COUNT(DISTINCT uj.session_id) AS session_count,
+
+    -- Conversion metric
+    DIV0(
+        COUNT(DISTINCT CASE WHEN uj.has_purchase THEN uj.user_id END),
+        COUNT(DISTINCT CASE WHEN uj.has_qv THEN uj.user_id END)
+    ) AS qv_to_purchase_rate,
+
+    -- Audit
+    CURRENT_TIMESTAMP() AS loaded_at
+
+FROM {{ ref('stg_user_journey_kl') }} uj
+JOIN {{ ref('dim_date_kl') }} d
+    ON CAST(uj.event_timestamp AS DATE) = d.full_date
+JOIN {{ ref('dim_geography_kl') }} g
+    ON uj.geo_country = g.country
+    AND uj.geo_zipcode = g.zipcode
+
+{% if is_incremental() %}
+-- Reprocess the latest loaded daily partition so MERGE can update metrics
+-- if source records for the latest date arrive or change after the prior run.
+WHERE d.date_key >= (
+    SELECT COALESCE(MAX(date_key), 0)
+    FROM {{ this }}
+)
+{% endif %}
+
+GROUP BY
+    d.date_key,
+    g.geo_key,
+    uj.device_class,
+    mkt_source,
+    mkt_campaign

--- a/models/data_mart/fact_user_engagement_kl.sql
+++ b/models/data_mart/fact_user_engagement_kl.sql
@@ -1,0 +1,72 @@
+/*
+****************************************************************************************************
+MODEL: fact_user_engagement_kl
+PURPOSE: 
+    - Enrich core user interaction data with geographical, marketing, and device-class dimensions.
+    - Support multi-channel marketing impact and territory management analysis.
+SOURCE: 
+    - raw.user_journey
+    - raw.user_data (Filtering for active accounts)
+    - raw.product_data (Validating product catalog alignment)
+BUSINESS VALUE:
+    - Provides visibility into "where" (GEO) and "how" (DEVICE) users are engaging.
+    - Connects search behavior (SEARCH_TERMS) to marketing initiatives (MKT_CAMPAIGN).
+    - Enables profile-based conversion analysis for Sales and Product teams.
+****************************************************************************************************
+*/
+
+{{ config(
+    materialized='incremental',
+    unique_key=['user_id', 'product_id', 'search_event_id', 'timestamp']
+) }}
+
+-- Step 1: Broaden raw journey data by adding your requested business dimensions
+WITH engagement_base AS (
+    SELECT
+        uj.user_id,
+        uj.product_id,
+        uj.search_event_id,
+        uj.session_id,
+        -- Standardize timestamp for downstream analysis
+        to_timestamp(replace(uj.timestamp,' UTC','')) AS timestamp,
+        uj.has_qv,
+        uj.has_pdp,
+        uj.has_atc,
+        uj.has_purchase,
+        -- Geography for Territory Management
+        uj.geo_country,
+        uj.geo_zipcode,
+        -- Marketing for Multi-Channel Analysis
+        uj.search_terms,        -- ✅ 修正: search_terms (复数)
+        uj.mkt_campaign,
+        uj.mkt_source,
+        -- Platform for Customer Profile Analysis
+        uj.device_class
+    FROM {{ source('de_project', 'user_journey') }} uj
+),
+
+-- Step 2: Validate against active user accounts
+valid_users AS (
+    SELECT
+        u.user_id
+    FROM {{ source('de_project', 'user_data') }} u
+    WHERE u.account_status = 'active'
+),
+
+-- Step 3: Validate against existing product master data
+valid_products AS (
+    SELECT
+        p.product_id
+    FROM {{ source('de_project', 'product_data') }} p
+),
+
+-- Step 4: Final join to ensure data quality and integrity
+final_engagement AS (
+    SELECT
+        eb.*
+    FROM engagement_base eb
+    INNER JOIN valid_users vu ON eb.user_id = vu.user_id
+    INNER JOIN valid_products vp ON eb.product_id = vp.product_id
+)
+
+SELECT * FROM final_engagement

--- a/models/data_mart/fact_user_transaction_kl.sql
+++ b/models/data_mart/fact_user_transaction_kl.sql
@@ -1,0 +1,76 @@
+/*
+****************************************************************************************************
+MODEL: fact_user_transaction_kl
+PURPOSE: 
+    - Consolidate purchase events with product pricing to calculate revenue.
+    - Analyze "Deal Size" and customer basket composition at a daily grain.
+    - Support cross-selling analysis via product category aggregation.
+SOURCE: 
+    - raw.user_journey (Filter: has_purchase = TRUE)
+    - raw.product_data (For price and category enrichment)
+BUSINESS VALUE:
+    - Identifies High/Medium/Low value transactions (Deal Size).
+    - Enables "Products per Order" metrics (Product Count).
+    - Cross Selling Detection by using LISTAGG.
+    - Provides visibility into multi-category purchasing behavior (Category List).
+****************************************************************************************************
+*/
+
+{{ config(
+    materialized='incremental',
+    unique_key=['user_id', 'product_id', 'timestamp']
+) }}
+
+-- Step 1: Extract successful transactions and join with product metadata
+WITH base_transactions AS (
+    SELECT
+        uj.user_id,
+        uj.product_id,
+        uj.search_event_id,
+        uj.session_id,
+        uj.cart_id,
+        -- Standardize timestamp for window function calculations not within 'UTC' for future category by 'Date'
+        to_timestamp(replace(uj.timestamp,' UTC','')) AS timestamp,
+        p.product_category,
+        p.price
+    FROM {{ source('de_project', 'user_journey') }} uj
+    LEFT JOIN {{ source('de_project', 'product_data') }} p 
+      ON uj.product_id = p.product_id
+    WHERE uj.has_purchase = TRUE
+),
+
+-- Step 2: Calculate aggregate metrics per user/day using Window Functions
+-- This preserves individual row detail while adding group-level context
+transaction_aggregation AS (
+    SELECT
+        *,
+        -- Total spend per user per day to determine deal size
+        SUM(price) OVER (PARTITION BY user_id, CAST(timestamp AS DATE)) AS daily_user_spend,
+        
+        -- Count of unique products purchased by user on this date
+        COUNT(DISTINCT product_id) OVER (PARTITION BY user_id, CAST(timestamp AS DATE)) AS products_count,
+        
+        -- Concatenate unique categories purchased by user on this date
+        LISTAGG(DISTINCT product_category, ', ') OVER (PARTITION BY user_id, CAST(timestamp AS DATE)) AS product_categories
+    FROM base_transactions
+)
+
+-- Step 3: Final output with Deal Size classification logic
+SELECT
+    user_id,
+    product_id,
+    timestamp,
+    search_event_id,
+    session_id,
+    cart_id,
+    price AS item_price,
+    daily_user_spend AS total_amount,
+    products_count,
+    product_categories,
+    -- Segmentation based on daily total spend
+    CASE 
+        WHEN daily_user_spend >= 500 THEN 'Large'
+        WHEN daily_user_spend BETWEEN 100 AND 499 THEN 'Medium'
+        ELSE 'Small'
+    END AS deal_size
+FROM transaction_aggregation


### PR DESCRIPTION
## Summary
- Adds Week 5 required models and related business enhancements.
- Updates `fact_daily_metrics_kl` incremental merge key to match the model grain.
- Adds a targeted data test for daily fact grain uniqueness and dimension key integrity.

## Why
The daily metrics model grain is `date_key + geo_key + device_class + mkt_source + mkt_campaign`, so the dbt unique key should include the marketing fields as well. This prevents merge/upsert collisions across different marketing source/campaign combinations.

## Validation
- `dbt parse` passed
- `dbt run --select dim_date_kl dim_geography_kl stg_user_journey_kl fact_daily_metrics_kl` passed
- `dbt test --select test_fact_daily_metrics_kl` passed
